### PR TITLE
feat(es): port reindex bits (reshard, remote, replicas:0)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     services:
       elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.16
         options: >-
-          --health-cmd "curl http://localhost:9200/_cluster/health"
+          --health-cmd "curl -s -u elastic:changeme http://localhost:9200/_cluster/health"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
@@ -24,11 +24,15 @@ jobs:
           ES_JAVA_OPTS: -Xms256m -Xmx256m
           discovery.type: single-node
           cluster.name: datashare
+          ELASTIC_PASSWORD: changeme
+          xpack.security.enabled: "true"
+          xpack.security.http.ssl.enabled: "false"
           http.compression: false
           http.cors.enabled: true
           http.cors.allow-origin: "*"
           http.cors.allow-methods: OPTIONS, HEAD, GET, POST, PUT, DELETE
           indices.query.bool.max_clause_count: 20000
+          reindex.remote.whitelist: "localhost:9200,127.0.0.1:9200"
       redis:
         image: redis:7-alpine
         options: >-
@@ -40,7 +44,7 @@ jobs:
           - 6379:6379
 
     env:
-      ELASTICSEARCH_URL: http://localhost:9200
+      ELASTICSEARCH_URL: http://elastic:changeme@localhost:9200
       REDIS_URL: redis://localhost:6379
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Here are the main scripts available in this repository:
 │   │
 │   ├── index
 │   │   ├── clone.sh # Clone a given index into another
-│   │   ├── create.sh # Create an index using default Datashare settings
+│   │   ├── create.sh # Create an index using default Datashare settings (optional --shards <n>)
 │   │   ├── delete.sh # Delete an index
 │   │   ├── list.sh # Get all indices
 │   │   ├── number_of_replicas.sh # Get or change number of replicas for a given index
@@ -52,8 +52,9 @@ Here are the main scripts available in this repository:
 │   │   ├── refresh.sh # Refresh a given index
 │   │   ├── refresh_interval.sh # Get or change refresh interval for a given index
 │   │   ├── reindex.sh # Reindex everything from a given index
+│   │   ├── remote_reindex.sh # Reindex an index from a remote cluster into another (with auth)
 │   │   ├── replace.sh # Replace an index by another one
-│   │   └── safe_reindex.sh # Safely reindex an index with backup and verification
+│   │   └── safe_reindex.sh # Safely reindex an index with backup and verification (optional --shards <n>)
 │   │
 │   ├── named_entity
 │   │   ├── count.sh # Count named entities
@@ -160,6 +161,38 @@ This opperation might be useful if mapping or settings of the index changed.
 
 ```bash
 ./elasticsearch/index/replace.sh ricecake-tmp ricecake
+```
+
+### Re-shard an index
+
+To change the number of shards of an index in place, `safe_reindex.sh` accepts a
+`--shards` option. It reindexes into a temporary index with the new shard count
+(dropping replicas to 0 during the copy for speed), verifies the document count and
+swaps it back, keeping a backup:
+
+```bash
+./elasticsearch/index/safe_reindex.sh --shards 12 ricecake
+```
+
+### Reindex from a remote cluster
+
+To copy an index from another Elasticsearch cluster into this one (the source index is
+left untouched). The **destination** cluster must whitelist the remote host in its
+`elasticsearch.yml` (`reindex.remote.whitelist: "origin-host:9200"`):
+
+```bash
+./elasticsearch/index/remote_reindex.sh --remote-es-url https://origin-host:9200 ricecake
+```
+
+Credentials can be embedded in the URL (URL-encode special characters, e.g. `@` → `%40`),
+the destination defaults to `ELASTICSEARCH_URL`, and you can rename or re-shard on the way:
+
+```bash
+./elasticsearch/index/remote_reindex.sh \
+  --remote-es-url https://user:p%40ss@origin-host:9200 \
+  --destination-es-url http://localhost:9200 \
+  --shards 12 \
+  ricecake ricecake-new
 ```
 
 ### Queue files (for indexing)

--- a/elasticsearch/index/create.sh
+++ b/elasticsearch/index/create.sh
@@ -3,7 +3,14 @@
 script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source $script_dir/../../lib/cli.sh
 
-check_usage 1 '<index> [<version>]'
+# Optional --shards|-s flag to override the default number of shards
+shards=
+while [[ "$1" == "--shards" || "$1" == "-s" ]]; do
+  shards=$2
+  shift 2
+done
+
+check_usage 1 '[--shards|-s <n>] <index> [<version>]'
 check_env
 check_bins
 check_elasticsearch_url
@@ -31,6 +38,11 @@ mappings_json=$resources_dir/datashare_index_mappings.json
 settings_json=$resources_dir/datashare_index_settings.json
 # Combine contents of mappings and settings JSON files into one body
 body=$(jq --slurpfile mappings $mappings_json '{ "mappings": $mappings[0], "settings": . }' $settings_json)
+
+# Override the number of shards if requested
+if [[ -n "$shards" ]]; then
+  body=$(echo "$body" | jq --argjson n "$shards" '.settings["index.number_of_shards"] = $n')
+fi
 
 spinner_start "Create index"
 if ! curl -sXPUT "$ELASTICSEARCH_URL/$1" -H 'Content-Type: application/json' -d "$body" | jq -e '.acknowledged' > /dev/null; then

--- a/elasticsearch/index/remote_reindex.sh
+++ b/elasticsearch/index/remote_reindex.sh
@@ -1,0 +1,165 @@
+#!/bin/bash -e
+
+# Reindex an index FROM a remote Elasticsearch cluster INTO a destination cluster
+# using the Reindex API with a remote source. It does NOT delete the source index.
+#
+# PREREQUISITE: the destination cluster must whitelist the remote host in
+# elasticsearch.yml, e.g.:
+#   reindex.remote.whitelist: "remote-host:9200"
+#
+# Auth can be embedded in the remote URL (https://user:pass@host:9200), with any
+# special character URL-encoded (e.g. @ -> %40).
+
+script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $script_dir/../../lib/cli.sh
+
+# Flags
+remote_url=
+destination_url=
+shards=
+while [[ "$1" == --* || "$1" == -s ]]; do
+  case "$1" in
+    --remote-es-url) remote_url=${2%/}; shift 2 ;;
+    --destination-es-url) destination_url=${2%/}; shift 2 ;;
+    --shards|-s) shards=$2; shift 2 ;;
+    *) log_error "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+check_usage 1 '--remote-es-url <url> [--destination-es-url <url>] [--shards|-s <n>] <source_index> [<dest_index>]'
+check_env
+check_bins
+
+# The destination defaults to ELASTICSEARCH_URL when not given explicitly
+if [[ -z "$destination_url" ]]; then
+  check_elasticsearch_url
+  destination_url=${ELASTICSEARCH_URL%/}
+fi
+
+if [[ -z "$remote_url" ]]; then
+  log_error "--remote-es-url is required"
+  exit 1
+fi
+
+source_index=$1
+dest_index=${2:-$1}
+
+log_title "Remote Reindex: $source_index → $dest_index"
+
+# Parse scheme, host and (optional) credentials out of the remote URL
+remote_scheme=$(echo "$remote_url" | sed -E 's|(https?)://.*|\1|')
+if echo "$remote_url" | grep -q '@'; then
+  remote_auth=$(echo "$remote_url" | sed -E 's|https?://([^@]+)@.*|\1|')
+  remote_user=$(echo "$remote_auth" | cut -d: -f1)
+  remote_pass=$(echo "$remote_auth" | cut -d: -f2-)
+  remote_host=$(echo "$remote_url" | sed -E 's|https?://[^@]+@([^/]+).*|\1|')
+else
+  remote_host=$(echo "$remote_url" | sed -E 's|https?://([^/]+).*|\1|')
+  remote_user=""
+  remote_pass=""
+fi
+
+log_kv "Remote source" "$remote_scheme://$remote_host/$source_index"
+log_kv "Destination" "$destination_url/$dest_index"
+
+# 1. Fetch settings, mappings and aliases from the remote source index
+spinner_start "Fetch settings/mappings from remote"
+index_config=$(curl -s "$remote_url/$source_index")
+settings=$(echo "$index_config" | jq --raw-output '.[].settings.index | del(.uuid, .version, .provided_name, .creation_date, .number_of_replicas)')
+mappings=$(echo "$index_config" | jq '.[].mappings')
+aliases=$(echo "$index_config" | jq '.[].aliases')
+if [[ -z "$settings" || "$settings" == "null" ]]; then
+  spinner_error "Fetch settings/mappings from remote"
+  echo ""
+  log_error "Could not read '$source_index' from remote cluster"
+  exit 1
+fi
+spinner_stop "Fetch settings/mappings from remote"
+
+# 2. Build the destination index body: 0 replicas for a fast/cheap copy,
+#    optional shard override, and drop settings that can't be set on create
+body=$(jq -n --argjson settings "$settings" --argjson mappings "$mappings" --argjson aliases "$aliases" \
+  '{ settings: $settings, mappings: $mappings, aliases: $aliases }')
+body=$(echo "$body" | jq '.settings.number_of_replicas = 0
+  | del(.settings.resize)
+  | del(.settings.routing.allocation.initial_recovery)')
+if [[ -n "$shards" ]]; then
+  body=$(echo "$body" | jq --argjson n "$shards" '.settings.number_of_shards = $n')
+fi
+
+# 3. Create the destination index
+spinner_start "Create destination index"
+if ! curl -sXPUT "$destination_url/$dest_index" -H 'Content-Type: application/json' -d "$body" | jq -e '.acknowledged' > /dev/null; then
+  spinner_error "Create destination index"
+  echo ""
+  log_error "Failed to create destination index '$dest_index'"
+  exit 1
+fi
+spinner_stop "Create destination index"
+
+# 4. Start the remote reindex asynchronously
+if [[ -n "$remote_user" ]]; then
+  remote_user_decoded=$(printf '%b' "${remote_user//%/\\x}")
+  remote_pass_decoded=$(printf '%b' "${remote_pass//%/\\x}")
+  remote_config=$(jq -n --arg host "$remote_scheme://$remote_host" --arg u "$remote_user_decoded" --arg p "$remote_pass_decoded" \
+    '{ host: $host, username: $u, password: $p }')
+else
+  remote_config=$(jq -n --arg host "$remote_scheme://$remote_host" '{ host: $host }')
+fi
+reindex_body=$(jq -n --argjson remote "$remote_config" --arg src "$source_index" --arg dst "$dest_index" \
+  '{ source: { remote: $remote, index: $src }, dest: { index: $dst } }')
+
+spinner_start "Start remote reindex"
+task_id=$(curl -sXPOST "$destination_url/_reindex?wait_for_completion=false" -H 'Content-Type: application/json' -d "$reindex_body" | jq -r '.task')
+if [[ "$task_id" == "null" || -z "$task_id" ]]; then
+  spinner_error "Start remote reindex"
+  echo ""
+  log_error "Failed to start remote reindex task"
+  exit 1
+fi
+spinner_stop "Start remote reindex"
+
+# 5. Monitor the task on the destination cluster until it completes
+spinner_start "Reindex data"
+while true; do
+  task_status=$(curl -s "$destination_url/_tasks/$task_id")
+  completed=$(echo "$task_status" | jq -r '.completed')
+  if [[ "$completed" == "true" ]]; then
+    break
+  fi
+  sleep 2
+done
+failures=$(curl -s "$destination_url/_tasks/$task_id" | jq '.response.failures | length')
+if [[ "$failures" != "0" && "$failures" != "null" ]]; then
+  spinner_error "Reindex data"
+  echo ""
+  log_error "Remote reindex completed with $failures failures"
+  exit 1
+fi
+spinner_stop "Reindex data"
+
+# 6. Verify document counts match
+spinner_start "Verify document count"
+curl -s -XPOST "$destination_url/$dest_index/_refresh" > /dev/null
+source_count=$(curl -s "$remote_url/$source_index/_count" | jq '.count')
+dest_count=$(curl -s "$destination_url/$dest_index/_count" | jq '.count')
+if [[ "$source_count" != "$dest_count" ]]; then
+  spinner_error "Verify document count"
+  echo ""
+  log_error "Document count mismatch! Source: $source_count, Dest: $dest_count"
+  exit 1
+fi
+spinner_stop "Verify document count"
+
+# 7. Restore replicas on the destination index (curl directly, as the destination
+#    cluster may differ from ELASTICSEARCH_URL used by number_of_replicas.sh)
+spinner_start "Restore replicas"
+if ! curl -sXPUT "$destination_url/$dest_index/_settings" -H 'Content-Type: application/json' -d'{ "index": { "number_of_replicas": 1 } }' | jq -e '.acknowledged' > /dev/null; then
+  spinner_error "Restore replicas"
+  exit 1
+fi
+spinner_stop "Restore replicas"
+
+echo ""
+log_kv "Destination index contains" "$dest_count documents"
+log_info "Remote reindex completed (source left untouched)"

--- a/elasticsearch/index/safe_reindex.sh
+++ b/elasticsearch/index/safe_reindex.sh
@@ -3,7 +3,14 @@
 script_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source $script_dir/../../lib/cli.sh
 
-check_usage 1 '<index> [<version>]'
+# Optional --shards|-s flag to reindex into an index with a different shard count
+shards=
+while [[ "$1" == "--shards" || "$1" == "-s" ]]; do
+  shards=$2
+  shift 2
+done
+
+check_usage 1 '[--shards|-s <n>] <index> [<version>]'
 check_env
 check_bins
 check_elasticsearch_url
@@ -17,6 +24,7 @@ new_index="${index_name}${temp_suffix}"
 # Global variables for results
 BACKUP_INDEX=""
 DOC_COUNT=0
+ORIGINAL_REPLICAS=1
 
 check_index_exists() {
     local index=$1
@@ -34,21 +42,22 @@ create_new_index() {
     local target_index=$1
     spinner_start "Create temporary index"
 
-    # Use create.sh to create the index with settings/mappings
+    # Build create.sh arguments: optional shard override, index name, optional version
+    local create_args=()
+    if [[ -n "$shards" ]]; then
+        create_args+=(--shards "$shards")
+    fi
+    create_args+=("$target_index")
     if [[ -n "$version" ]]; then
-        if ! "$script_dir/create.sh" "$target_index" "$version" > /dev/null; then
-            spinner_error "Create temporary index"
-            echo ""
-            log_error "Failed to create new index '$target_index'"
-            exit 1
-        fi
-    else
-        if ! "$script_dir/create.sh" "$target_index" > /dev/null; then
-            spinner_error "Create temporary index"
-            echo ""
-            log_error "Failed to create new index '$target_index'"
-            exit 1
-        fi
+        create_args+=("$version")
+    fi
+
+    # Use create.sh to create the index with settings/mappings
+    if ! "$script_dir/create.sh" "${create_args[@]}" > /dev/null; then
+        spinner_error "Create temporary index"
+        echo ""
+        log_error "Failed to create new index '$target_index'"
+        exit 1
     fi
     spinner_stop "Create temporary index"
 }
@@ -89,6 +98,21 @@ reindex_data() {
         exit 1
     fi
     spinner_stop "Reindex data"
+}
+
+capture_original_replicas() {
+    local index=$1
+    local replicas
+    replicas=$(curl -s "$ELASTICSEARCH_URL/$index/_settings" | jq -r ".\"$index\".settings.index.number_of_replicas // empty")
+    if [[ -n "$replicas" ]]; then
+        ORIGINAL_REPLICAS=$replicas
+    fi
+}
+
+set_replicas() {
+    local index=$1
+    local replicas=$2
+    "$script_dir/number_of_replicas.sh" "$index" "$replicas" > /dev/null
 }
 
 verify_document_count() {
@@ -192,10 +216,15 @@ main() {
 
     # Execute steps
     check_index_exists "$index_name"
+    capture_original_replicas "$index_name"
     create_new_index "$new_index"
+    # Drop replicas to 0 on the temporary index to speed up the reindex and save disk;
+    # the final index inherits this from the clone, so we restore the count at the end
+    set_replicas "$new_index" 0
     reindex_data "$index_name" "$new_index"
     verify_document_count "$index_name" "$new_index"
     swap_indices "$index_name" "$new_index"
+    set_replicas "$index_name" "$ORIGINAL_REPLICAS"
 
     # Final count
     "$script_dir/refresh.sh" "$index_name" > /dev/null

--- a/test/units/elasticsearch/index/create.bats
+++ b/test/units/elasticsearch/index/create.bats
@@ -39,3 +39,11 @@ teardown() {
     run ./elasticsearch/index/list.sh
     assert_output --partial $TEST_INDEX_FOO
 }
+
+@test "can create an index with a custom shard count" {
+    run ./elasticsearch/index/create.sh --shards 3 $TEST_INDEX_FOO
+    assert_success
+
+    shards=$(curl -s "$ELASTICSEARCH_URL/$TEST_INDEX_FOO/_settings" | jq -r ".\"$TEST_INDEX_FOO\".settings.index.number_of_shards")
+    assert_equal "$shards" "3"
+}

--- a/test/units/elasticsearch/index/remote_reindex.bats
+++ b/test/units/elasticsearch/index/remote_reindex.bats
@@ -1,0 +1,77 @@
+setup() {
+  load ../../../test_helper/bats-assert/load
+  load ../../../test_helper/bats-support/load
+
+  # Source .env to get ELASTICSEARCH_URL
+  if [[ -f .env ]]; then
+    source .env
+  fi
+  export ELASTICSEARCH_URL=${ELASTICSEARCH_URL:-http://elasticsearch:9200}
+
+  TEST_SRC="bats.index.remote_reindex.src"
+  TEST_DST="bats.index.remote_reindex.dst"
+
+  H_CONTENT_TYPE="Content-Type: application/json"
+
+  # Cleanup any leftover test indices
+  curl -sXDELETE "$ELASTICSEARCH_URL/$TEST_SRC" > /dev/null 2>&1 || true
+  curl -sXDELETE "$ELASTICSEARCH_URL/$TEST_DST" > /dev/null 2>&1 || true
+
+  # Create the source index with Datashare mappings and a few documents
+  local resources_dir="./elasticsearch/index/resources"
+  local body=$(jq --slurpfile mappings $resources_dir/datashare_index_mappings.json \
+    '{ "mappings": $mappings[0], "settings": . }' $resources_dir/datashare_index_settings.json)
+  curl -sXPUT "$ELASTICSEARCH_URL/$TEST_SRC" -H "$H_CONTENT_TYPE" -d "$body" > /dev/null
+
+  curl -sXPOST "$ELASTICSEARCH_URL/$TEST_SRC/_doc/1" -d'{ "name": "doc1", "path": "/test", "type": "Document" }' -H "$H_CONTENT_TYPE" > /dev/null
+  curl -sXPOST "$ELASTICSEARCH_URL/$TEST_SRC/_doc/2" -d'{ "name": "doc2", "path": "/test", "type": "Document" }' -H "$H_CONTENT_TYPE" > /dev/null
+  curl -sXPOST "$ELASTICSEARCH_URL/$TEST_SRC/_refresh" > /dev/null
+}
+
+
+teardown() {
+  curl -sXDELETE "$ELASTICSEARCH_URL/$TEST_SRC" > /dev/null 2>&1 || true
+  curl -sXDELETE "$ELASTICSEARCH_URL/$TEST_DST" > /dev/null 2>&1 || true
+}
+
+
+@test "cannot run remote_reindex without a source index" {
+    bats_require_minimum_version 1.5.0
+
+    run ! ./elasticsearch/index/remote_reindex.sh --remote-es-url "$ELASTICSEARCH_URL"
+}
+
+@test "remote_reindex requires --remote-es-url" {
+    bats_require_minimum_version 1.5.0
+
+    run ! ./elasticsearch/index/remote_reindex.sh $TEST_SRC
+    assert_output --partial "remote-es-url"
+}
+
+@test "remote_reindex copies documents to a new index and leaves the source untouched" {
+    src_count=$(curl -s "$ELASTICSEARCH_URL/$TEST_SRC/_count" | jq '.count')
+
+    # Treat the same cluster as the remote source (requires reindex.remote.whitelist)
+    run ./elasticsearch/index/remote_reindex.sh --remote-es-url "$ELASTICSEARCH_URL" $TEST_SRC $TEST_DST
+    assert_success
+
+    curl -sXPOST "$ELASTICSEARCH_URL/$TEST_DST/_refresh" > /dev/null
+    dst_count=$(curl -s "$ELASTICSEARCH_URL/$TEST_DST/_count" | jq '.count')
+    assert_equal "$src_count" "$dst_count"
+
+    # Source must still exist with the same documents
+    src_count_after=$(curl -s "$ELASTICSEARCH_URL/$TEST_SRC/_count" | jq '.count')
+    assert_equal "$src_count" "$src_count_after"
+
+    # Destination replicas restored to 1
+    replicas=$(curl -s "$ELASTICSEARCH_URL/$TEST_DST/_settings" | jq -r ".\"$TEST_DST\".settings.index.number_of_replicas")
+    assert_equal "$replicas" "1"
+}
+
+@test "remote_reindex can change the shard count on the destination" {
+    run ./elasticsearch/index/remote_reindex.sh --remote-es-url "$ELASTICSEARCH_URL" --shards 3 $TEST_SRC $TEST_DST
+    assert_success
+
+    shards=$(curl -s "$ELASTICSEARCH_URL/$TEST_DST/_settings" | jq -r ".\"$TEST_DST\".settings.index.number_of_shards")
+    assert_equal "$shards" "3"
+}

--- a/test/units/elasticsearch/index/safe_reindex.bats
+++ b/test/units/elasticsearch/index/safe_reindex.bats
@@ -84,6 +84,24 @@ teardown() {
     assert [ "$backup_indices" -ge 1 ]
 }
 
+@test "safe_reindex can change the shard count while preserving documents" {
+    initial_count=$(curl -s "$ELASTICSEARCH_URL/$TEST_INDEX/_count" | jq '.count')
+
+    # Reindex into 3 shards
+    run bash -c "echo 'y' | ./elasticsearch/index/safe_reindex.sh --shards 3 $TEST_INDEX"
+    assert_success
+
+    curl -sXPOST "$ELASTICSEARCH_URL/$TEST_INDEX/_refresh" > /dev/null
+    final_count=$(curl -s "$ELASTICSEARCH_URL/$TEST_INDEX/_count" | jq '.count')
+    assert_equal "$initial_count" "$final_count"
+
+    # The final index must carry the new shard count and keep replicas at 1
+    shards=$(curl -s "$ELASTICSEARCH_URL/$TEST_INDEX/_settings" | jq -r ".\"$TEST_INDEX\".settings.index.number_of_shards")
+    assert_equal "$shards" "3"
+    replicas=$(curl -s "$ELASTICSEARCH_URL/$TEST_INDEX/_settings" | jq -r ".\"$TEST_INDEX\".settings.index.number_of_replicas")
+    assert_equal "$replicas" "1"
+}
+
 @test "safe_reindex preserves document content" {
     # Run safe_reindex
     run bash -c "echo 'y' | ./elasticsearch/index/safe_reindex.sh $TEST_INDEX"


### PR DESCRIPTION
brought to the playground the stuff we use in systems:

- create.sh: --shards|-s flag to override number_of_shards
- safe_reindex.sh: passes --shards through, and drops replicas to 0 during the copy to go faster/cheaper, restores the original count at the end
- remote_reindex.sh: new, reindex from a remote cluster with --remote-es-url/--destination-es-url, parses auth from the url, does NOT delete the source
- bumped CI es to 8.19.16
- reindex.remote.whitelist on the test es so the remote test can reindex from itself
- bats tests for the 3 + readme (tree + cookbook)

tested vs es 8.19.16, 7.9.1 and against staging -> luxleaks and macronleaks migrated